### PR TITLE
Enable excluding rows for certain tables

### DIFF
--- a/source code/MySqlBackup(MySqlConnector)/InfoObjects/ExportInformations.cs
+++ b/source code/MySqlBackup(MySqlConnector)/InfoObjects/ExportInformations.cs
@@ -19,7 +19,8 @@ namespace MySqlConnector
         Dictionary<string, string> _customTable = new Dictionary<string, string>();
 
         List<string> _lstExcludeTables = null;
-        
+        List<string> _lstExcludeRowsForTables = null;
+
         /// <summary>
         /// Gets or Sets the tables (black list) that will be excluded for export. The rows of the these tables will not be exported too.
         /// </summary>
@@ -34,6 +35,23 @@ namespace MySqlConnector
             set
             {
                 _lstExcludeTables = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or Sets the tables (black list) that will be excluded for row export.
+        /// </summary>
+        public List<string> ExcludeRowsForTables
+        {
+            get
+            {
+                if (_lstExcludeRowsForTables == null)
+                    _lstExcludeRowsForTables = new List<string>();
+                return _lstExcludeRowsForTables;
+            }
+            set
+            {
+                _lstExcludeRowsForTables = value;
             }
         }
 

--- a/source code/MySqlBackup(MySqlConnector)/MySqlBackup.cs
+++ b/source code/MySqlBackup(MySqlConnector)/MySqlBackup.cs
@@ -381,7 +381,8 @@ namespace MySqlConnector
                     if (ExportInfo.ExportTableStructure)
                         Export_TableStructure(tableName);
 
-                    if (ExportInfo.ExportRows)
+                    var excludeRows = Export_ThisRowForTableIsExcluded(tableName);
+                    if (ExportInfo.ExportRows && !excludeRows)
                         Export_Rows(tableName, selectSQL);
                 }
             }
@@ -392,6 +393,19 @@ namespace MySqlConnector
             string tableNameLower = tableName.ToLower();
 
             foreach (string blacklistedTable in ExportInfo.ExcludeTables)
+            {
+                if (blacklistedTable.ToLower() == tableNameLower)
+                    return true;
+            }
+
+            return false;
+        }
+
+        bool Export_ThisRowForTableIsExcluded(string tableName)
+        {
+            var tableNameLower = tableName.ToLower();
+
+            foreach (var blacklistedTable in ExportInfo.ExcludeRowsForTables)
             {
                 if (blacklistedTable.ToLower() == tableNameLower)
                     return true;


### PR DESCRIPTION
Enables excluding rows for certain tables instead of all. We have a large table that we want to have the table created but the rows excluded.